### PR TITLE
fix typo in init() function

### DIFF
--- a/PaymentPaypal.module
+++ b/PaymentPaypal.module
@@ -28,7 +28,7 @@ class PaymentPaypal extends PaymentModule {
   }
 
   public function init() {
-    $this->currenct = $this->defaultCurrency;
+    $this->currency = $this->defaultCurrency;
   }
 
   public function getTitle() {


### PR DESCRIPTION
there is a typo in setting the currency variable
